### PR TITLE
Fix current language error

### DIFF
--- a/nece/managers.py
+++ b/nece/managers.py
@@ -47,13 +47,13 @@ class TranslationMixin:
     def is_default_language(self, language_code):
         """Return true if language_code is the default, in case language_code is none it will retrieve it from the thread."""
         if language_code is None:
-            language_code = self._get_language_code()
+            language_code = self.get_language_code()
             self._language_code = language_code
         else:
             language_code = self.get_language_key(language_code)
         return language_code == TRANSLATIONS_DEFAULT
 
-    def _get_language_code(self):
+    def get_language_code(self):
         language = get_language() or self._default_language_code
         language_code = language.replace("-", "_")
         return language_code
@@ -212,7 +212,7 @@ class TranslationManager(models.Manager, TranslationMixin):
         qs = self._queryset_class(self.model, using=self.db, hints=self._hints)
         language_code = self.get_language_key(language_code)
         if language_code is None:
-            language_code = self._get_language_code()
+            language_code = self.get_language_code()
         qs.language(language_code)
         return qs
 

--- a/nece/managers.py
+++ b/nece/managers.py
@@ -208,7 +208,8 @@ class TranslationManager(models.Manager, TranslationMixin):
         language_code = self.get_language_key(
             language_code
         )
-        current_language = get_language().replace("-", "_")
+        current_language = get_language() or settings.TRANSLATIONS_DEFAULT
+        current_language = current_language.replace("-", "_")
         if language_code is None:
             language_code = current_language
         qs.language(language_code)

--- a/nece/managers.py
+++ b/nece/managers.py
@@ -47,11 +47,16 @@ class TranslationMixin:
     def is_default_language(self, language_code):
         """Return true if language_code is the default, in case language_code is none it will retrieve it from the thread."""
         if language_code is None:
-            language_code = get_language().replace("-", "_")
+            language_code = self._get_language_code()
             self._language_code = language_code
         else:
             language_code = self.get_language_key(language_code)
         return language_code == TRANSLATIONS_DEFAULT
+
+    def _get_language_code(self):
+        language = get_language() or self._default_language_code
+        language_code = language.replace("-", "_")
+        return language_code
 
 
 class TranslationModelIterable(ModelIterable):
@@ -205,13 +210,9 @@ class TranslationManager(models.Manager, TranslationMixin):
         It will also call `get_language` in order to retrieve the current language of the thread if not specified.
         """
         qs = self._queryset_class(self.model, using=self.db, hints=self._hints)
-        language_code = self.get_language_key(
-            language_code
-        )
-        current_language = get_language() or TRANSLATIONS_DEFAULT
-        current_language = current_language.replace("-", "_")
+        language_code = self.get_language_key(language_code)
         if language_code is None:
-            language_code = current_language
+            language_code = self._get_language_code()
         qs.language(language_code)
         return qs
 

--- a/nece/managers.py
+++ b/nece/managers.py
@@ -208,7 +208,7 @@ class TranslationManager(models.Manager, TranslationMixin):
         language_code = self.get_language_key(
             language_code
         )
-        current_language = get_language() or settings.TRANSLATIONS_DEFAULT
+        current_language = get_language() or TRANSLATIONS_DEFAULT
         current_language = current_language.replace("-", "_")
         if language_code is None:
             language_code = current_language

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -152,7 +152,7 @@ class TranslationTest(TestCase):
 
     @patch("django.utils.translation._trans.get_language", return_value=None)
     def test_get_language_code(self, _):
-        language_code = Fruit.objects._get_language_code()
+        language_code = Fruit.objects.get_language_code()
         self.assertEqual(language_code, "en_us")
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,4 +1,6 @@
 import os
+from unittest.mock import patch
+
 import mock
 
 from django.core.management import call_command
@@ -147,6 +149,11 @@ class TranslationTest(TestCase):
         names = Fruit.objects.values()
         self.assertEqual(names.count(), Fruit.objects.count())
         self.assertEqual(len(names), Fruit.objects.count())
+
+    @patch("django.utils.translation._trans.get_language", return_value=None)
+    def test_get_language_code(self, _):
+        language_code = Fruit.objects._get_language_code()
+        self.assertEqual(language_code, "en_us")
 
 
 class TranslationOrderingTest(TestCase):


### PR DESCRIPTION
The issue that for some cases `get_language` method returns `None` and tries to apply `.replace()` as for string.
The fix just provide default translation language if there is a case .