### PR TITLE
Fix _clone to inject language properly

### DIFF
--- a/nece/managers.py
+++ b/nece/managers.py
@@ -96,11 +96,8 @@ class TranslationQuerySet(TranslationMixin, models.QuerySet):
 
     def _clone(self):
         """Override `_clone` method in order to inject the `language_code`."""
-        language_code = self._language_code
-        if language_code is None:
-            language_code = get_language().replace("-", "_")
         clone = super()._clone()
-        clone._language_code = language_code
+        clone._language_code = self._language_code or get_language().replace("-", "_")
         return clone
 
     @staticmethod

--- a/nece/managers.py
+++ b/nece/managers.py
@@ -96,8 +96,11 @@ class TranslationQuerySet(TranslationMixin, models.QuerySet):
 
     def _clone(self):
         """Override `_clone` method in order to inject the `language_code`."""
+        language_code = self._language_code
+        if language_code is None:
+            language_code = get_language().replace("-", "_")
         clone = super()._clone()
-        clone._language_code = self._language_code
+        clone._language_code = language_code
         return clone
 
     @staticmethod

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -5,7 +5,8 @@ import mock
 
 from django.core.management import call_command
 from django.test import RequestFactory, TestCase
-from django.utils.translation import override
+
+from django.utils.translation import override, activate
 
 from nece import managers
 from nece.middleware import NeceMiddleware
@@ -29,6 +30,10 @@ class TranslationTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         create_fixtures()
+
+    def tearDown(self) -> None:
+        """Make sure default language is always set before each run."""
+        activate("en-us")
 
     @staticmethod
     def test_basic_queries():
@@ -154,6 +159,19 @@ class TranslationTest(TestCase):
     def test_get_language_code(self, _):
         language_code = Fruit.objects.get_language_code()
         self.assertEqual(language_code, "en_us")
+
+    def test_get_all_based_on_default_language(self):
+        english_names = ["apple", "pear", "banana"]
+        french_names = ["pomme", "pear", "banana"]
+        turkish_names = ["elma", "armut", "banana"]
+        for fruit in Fruit.objects.all():
+            self.assertIn(fruit.name, english_names)
+        activate("fr-fr")
+        for fruit in Fruit.objects.all():
+            self.assertIn(fruit.name, french_names)
+        activate("tr-tr")
+        for fruit in Fruit.objects.all():
+            self.assertIn(fruit.name, turkish_names)
 
 
 class TranslationOrderingTest(TestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -32,7 +32,7 @@ class TranslationTest(TestCase):
         create_fixtures()
 
     def tearDown(self) -> None:
-        """Make sure default language is always set before each run."""
+        """Make sure default language is always set after each run."""
         activate("en-us")
 
     @staticmethod


### PR DESCRIPTION
### Problem

When all() is called, `def _clone()` is called, and the language_code is injected from the father to the son. But if there is no `_language_code` set in the father, it will be None even though the Language code is set globally at django.

This situation does not happen when calling `.filter()` because when `self.is_default_language(self._language_code)` is called, and there is no `self._language_code` set, `is_default_language` method pull from `django.utils.translation.get_language` and set as `self._language_code`.

### Fix

if there is no language code during `_clone` pull the language from django `django.utils.translation.get_language` and set as  `_language_code`.