### PR TITLE
Fix when creating/updating a record

### DIFF
--- a/nece/models.py
+++ b/nece/models.py
@@ -1,3 +1,4 @@
+from django.apps import apps
 from django.db import models
 from django.db.models import JSONField, options
 
@@ -112,10 +113,39 @@ class TranslationModel(models.Model, TranslationMixin):
         return {}
 
     def save(self, *args, **kwargs):
-        language_code = self._language_code
-        self.reset_language()
+        """
+        Populate translations properly when saving the object.
+
+        LANGUAGE != DEFAULT
+        - When creating a new object, the translatable field will be populated along with translations key.
+        - If the object already exists, then only translations key will be updated.
+
+        LANGUAGE = DEFAULT
+        - When creating a new object, the translatable field will be populated but not translations field.
+        - If the object already exists, then only translatable field will be updated.
+        - If the language is set to != DEFAULT, when updating the translations field will be populated, but not the
+          translatable field.
+        """
+        language_code = self.get_language_code()
         if self.translations == "":
             self.translations = None
+        self.reset_language()
+        if not self.is_default_language(language_code):
+            old_record = None
+            if self.pk:
+                model_klass = apps.get_model(app_label=self._meta.app_label, model_name=self.get_class_name())
+                old_record = model_klass.objects.get(id=self.pk)
+            for translatable_field in self._meta.translatable_fields:
+                new_field_value = getattr(self, translatable_field)
+                self.translate(language_code, **{translatable_field: new_field_value})
+                if not old_record:
+                    continue
+                # _translated needs to be set as None in order to be able to setattr.
+                self._translated = None
+                old_field_value = getattr(old_record, translatable_field)
+                if old_field_value != new_field_value:
+                    # The regular field should be kept the same as before. Only translations should be updated.
+                    setattr(self, translatable_field, old_field_value)
         super().save(*args, **kwargs)
         self.language(language_code)
 

--- a/nece/models.py
+++ b/nece/models.py
@@ -1,4 +1,3 @@
-from django.apps import apps
 from django.db import models
 from django.db.models import JSONField, options
 
@@ -133,8 +132,7 @@ class TranslationModel(models.Model, TranslationMixin):
         if not self.is_default_language(language_code):
             old_record = None
             if self.pk:
-                model_klass = apps.get_model(app_label=self._meta.app_label, model_name=self.get_class_name())
-                old_record = model_klass.objects.get(id=self.pk)
+                old_record = self.__class__.objects.get(id=self.pk)
             for translatable_field in self._meta.translatable_fields:
                 new_field_value = getattr(self, translatable_field)
                 self.translate(language_code, **{translatable_field: new_field_value})

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-nece
-version = 0.15.dev2
+version = 0.16.dev2
 description = A content translation framework using Postgresql's jsonb field in the background
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
### Problem

When the language is not DEFAULT, the translations are not populated automatically when creating/updating using a Django REST API. 

### Solution

Updated `save()` method to get the fields and translations populated following the use cases below.

#### Use case 1

- Set your language to English (Default)
- Create a new Fruit named `English Fruit`.
- Check the results.
  - In Django Admin, translations should be empty, and the name should be `English Fruit`.
- Set your language to French.
- Update the Fruit name to `French Fruit`.
- In Django admin, translations should be populated as `{"fr_ca": {"name": "French Fruit"}}` and the name should be kept as `English Fruit`.

#### Use case 2

- Set your language to French
- Create a new Fruit named `French Fruit`.
- Check the results.
  - In Django Admin, translations should be `{"fr_ca": {"name": "French Fruit"}}`, and the name should be `French Fruit`.
- Set your language to English.
- Update the Fruit name to `English Fruit`.
- In Django admin, translations should be `{"fr_ca": {"name": "French Fruit"}}` and the name should be `English Fruit`.